### PR TITLE
Modified getpos to work with multiple screens

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -823,17 +823,25 @@ function getpos(pos, scr_arg)
         -- if making another of an existing tag, return the end of
         -- the list the optional 2nd argument decides if we return
         -- only
-        if scr_arg ~= nil then
+        if scr_arg ~= nil or not selected then
             for _, tag in pairs(existing) do
-                if tag.screen == scr_arg then return tag end
+                if tag.screen == scr then return tag end
             end
             -- no tag with a position and scr_arg match found, clear
             -- v and allow the subseqeunt conditions to be evaluated
             v = nil
         else
-            v = (selected and
-                    existing[awful.util.cycle(#existing, selected + 1)]) or
-                    existing[1]
+            -- look for the next unselected tag in the list
+            i = selected
+            repeat
+                i = awful.util.cycle(#existing, i + 1)
+                tag = existing[i]
+
+                if not tag.selected then return tag end
+            until i == selected
+
+            -- no unselected tab found, select first tag
+            v = existing[selected]
         end
 
     end

--- a/init.lua
+++ b/init.lua
@@ -874,8 +874,11 @@ end
 function init()
     local numscr = capi.screen.count()
 
+    local screens = {}
+    for s = 1, capi.screen.count() do table.insert(screens, s) end
+
     for i, j in pairs(config.tags) do
-        local scr = j.screen or {1}
+        local scr = j.screen or screens
         if type(scr) ~= 'table' then
             scr = {scr}
         end


### PR DESCRIPTION
The getpos() function doesn't work very well with multiple screens.
It doesn't return correct tags when using it on other screens than the first.

Here is a corrected version of this function.

In the third commit, I changed the default behaviour to add a tag to every screen if the screen attribute is not defined for the tag.
