### PR TITLE
Restore previously focused client (issue #15)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -341,8 +341,11 @@ function set(t, args)
         index_cache[scr][t.name] = idx
     end
 
+    local c = capi.client.focus
     -- set tag properties and push the new tag table
     capi.screen[scr]:tags(tags)
+    -- restore previously focused client
+    if c ~= nil then capi.client.focus = c end
     for prop, val in pairs(props) do awful.tag.setproperty(t, prop, val) end
 
     -- execute run/spawn


### PR DESCRIPTION
Hello,

It seems that the function called at line 346 of init.lua unfocus the client

``` lua
 -- set tag properties and push the new tag table
capi.screen[scr]:tags(tags)
```

The only way I see right now to correct issue #15 is to restore previously focused client after this line.
