### PR TITLE
client-to-tag binding example doesn't work properly

### DIFF
--- a/example.rc.lua
+++ b/example.rc.lua
@@ -433,8 +433,11 @@ for i = 1, (shifty.config.maxtags or 9) do
         -- move clients to other tags
         awful.key({modkey, "Shift"}, i, function()
             if client.focus then
+                -- remember the focused client because getpos() switch
+                -- to new tag (if it doesn't exist) and the client lost focus
+                local c = client.focus
                 t = shifty.getpos(i)
-                awful.client.movetotag(t)
+                awful.client.movetotag(t, c)
                 awful.tag.viewonly(t)
             end
         end))


### PR DESCRIPTION
Hi,

When switching client to a new tag that doesn't exist, a new tag is created and switched to. This makes the current client lose focus and awful.client.movetotag(t) will fail because there is no client focused.

Attached is the working key-binding without changing the shifty library itself. Hope this helps =)
